### PR TITLE
Every good project should include tins #2!

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ GemHadar do
   licenses    << 'Apache-2.0'
 
   dependency             'json'
+  dependency             'tins'
   development_dependency 'rake'
   development_dependency 'simplecov'
   development_dependency 'rspec'


### PR DESCRIPTION
Its actually a runtime dependency. I accidently added it as a development_depedency earlier.