### PR TITLE
use new psych/yaml api when psych version < 4

### DIFF
--- a/lib/complex_config/provider.rb
+++ b/lib/complex_config/provider.rb
@@ -99,7 +99,11 @@ class ComplexConfig::Provider
         "configuration file #{pathname.to_s.inspect} is missing"
     end
     results = datas.map { |d| evaluate(pathname, d) }
-    hashes = results.map { |r| ::YAML.load(r, pathname) }
+    if ::Psych::VERSION < "4"
+      hashes = results.map { |r| ::YAML.load(r, pathname) }
+    else
+      hashes = results.map { |r| ::YAML.load(r, filename: pathname, aliases: true) }
+    end
     settings = ComplexConfig::Settings.build(name, hashes.shift)
     hashes.each { |h| settings.attributes_update(h) }
     if shared = settings.shared?

--- a/spec/complex_config/provider_spec.rb
+++ b/spec/complex_config/provider_spec.rb
@@ -269,6 +269,17 @@ RSpec.describe ComplexConfig::Provider do
     end
   end
 
+  context 'handling configuration files with aliases (considered unsafe)' do
+    before do
+      described_class.config_dir = Pathname.new(__FILE__).dirname.dirname + 'config'
+    end
+
+    it 'reads yaml files with aliases just fine' do
+      expect { described_class.config(asset('config_with_alias.yml')) }.not_to\
+        raise_error
+    end
+  end
+
   context 'evaluating configuration files with ERB' do
     it 'evaluates a config file correctly' do
       expect(

--- a/spec/config/config_with_alias.yml
+++ b/spec/config/config_with_alias.yml
@@ -1,0 +1,6 @@
+common: &common
+  extended: true
+
+specific:
+  <<: *common
+  foo: true


### PR DESCRIPTION
Psych 4.0.2 defaults to `safe_loading` where aliases cannot be used.
Behavior of evaluating aliases is retained.
Closes #4 .