### PR TITLE
Fix psych 4 DisallowedClass for symbols and dates:

### DIFF
--- a/lib/complex_config/provider.rb
+++ b/lib/complex_config/provider.rb
@@ -103,7 +103,7 @@ class ComplexConfig::Provider
       if ::Psych::VERSION < "4"
         results.map { |r| ::YAML.load(r, pathname) }
       else
-        results.map { |r| ::YAML.load(r, filename: pathname, aliases: true) }
+        results.map { |r| ::YAML.load(r, filename: pathname, aliases: true, permitted_classes: [Date, Symbol]) }
       end
     settings = ComplexConfig::Settings.build(name, hashes.shift)
     hashes.each { |h| settings.attributes_update(h) }


### PR DESCRIPTION
* fixes errors when using complex config with YAML files cotaining dates
  and symbols;